### PR TITLE
Added file_backend feature, allowing to stream to stdout or a file.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ AM_CFLAGS += -DJACK
 endif
 
 bin_PROGRAMS = vban_receptor
-vban_receptor_SOURCES = main.c audio.h audio.c socket.h socket.c vban.h logger.h logger.c audio_backend.h audio_backend.c pipe_backend.c pipe_backend.h
+vban_receptor_SOURCES = main.c audio.h audio.c socket.h socket.c vban.h logger.h logger.c audio_backend.h audio_backend.c pipe_backend.c pipe_backend.h file_backend.c file_backend.h
 
 if ALSA
 vban_receptor_SOURCES += alsa_backend.h alsa_backend.c 

--- a/src/audio_backend.c
+++ b/src/audio_backend.c
@@ -4,6 +4,7 @@
 #include "logger.h"
 
 #include "pipe_backend.h"
+#include "file_backend.h"
 #if ALSA
 #include "alsa_backend.h"
 #endif
@@ -31,7 +32,8 @@ static struct backend_list_item_t const backend_list[] =
     #if JACK
     { JACK_BACKEND_NAME, jack_backend_init },
     #endif
-    { PIPE_BACKEND_NAME, pipe_backend_init }
+    { PIPE_BACKEND_NAME, pipe_backend_init },
+    { FILE_BACKEND_NAME, file_backend_init }
 };
 
 int audio_backend_get_by_name(char const* name, audio_backend_handle_t* backend)

--- a/src/file_backend.c
+++ b/src/file_backend.c
@@ -40,32 +40,6 @@ static int file_open(audio_backend_handle_t handle, char const* output_name, enu
 static int file_close(audio_backend_handle_t handle);
 static int file_write(audio_backend_handle_t handle, char const* data, size_t nb_sample);
 
-unsigned int vban_sample_length(enum VBanBitResolution bit_resolution, unsigned int nb_channels)
-{
-    switch (bit_resolution)
-    {
-        case VBAN_BITFMT_8_INT:
-            return 1 * nb_channels;
-
-        case VBAN_BITFMT_16_INT:
-            return 2 * nb_channels;
-
-        case VBAN_BITFMT_24_INT:
-            return 3 * nb_channels;
-
-        case VBAN_BITFMT_32_INT:
-        case VBAN_BITFMT_32_FLOAT:
-            return 4 * nb_channels;
-
-        case VBAN_BITFMT_64_FLOAT:
-            return 8 * nb_channels;
-
-        default:
-            return 0;
-    }
-
-}
-
 int file_backend_init(audio_backend_handle_t* handle)
 {
     struct file_backend_t* file_backend = 0;
@@ -123,7 +97,7 @@ int file_open(audio_backend_handle_t handle, char const* output_name, enum VBanB
         return -errno;
     }
 
-    file_backend->sampleSize=vban_sample_length(bit_resolution, nb_channels);
+    file_backend->sampleSize=VBanBitResolutionSize[bit_resolution] * nb_channels;
     
     return 0;
 }

--- a/src/file_backend.c
+++ b/src/file_backend.c
@@ -1,0 +1,173 @@
+/*
+ *  This file is part of vban_receptor.
+ *  Copyright (c) 2015 by Benoît Quiniou <quiniouben@yahoo.fr>
+ *  Copyright (c) 2017 by Markus Buschhoff <markus.buschhoff@tu-dortmund.de>
+ *
+ *  vban_receptor is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  vban_receptor is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with vban_receptor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "file_backend.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include "logger.h"
+
+struct file_backend_t
+{
+    struct audio_backend_t  parent;
+    unsigned int sampleSize;
+    int	fd;
+};
+
+static int file_is_fmt_supported(audio_backend_handle_t handle, enum VBanBitResolution bit_resolution, unsigned int nb_channels, unsigned int rate);
+static int file_open(audio_backend_handle_t handle, char const* output_name, enum VBanBitResolution bit_resolution, unsigned int nb_channels, unsigned int rate, size_t buffer_size);
+static int file_close(audio_backend_handle_t handle);
+static int file_write(audio_backend_handle_t handle, char const* data, size_t nb_sample);
+
+unsigned int vban_sample_length(enum VBanBitResolution bit_resolution, unsigned int nb_channels)
+{
+    switch (bit_resolution)
+    {
+        case VBAN_BITFMT_8_INT:
+            return 1 * nb_channels;
+
+        case VBAN_BITFMT_16_INT:
+            return 2 * nb_channels;
+
+        case VBAN_BITFMT_24_INT:
+            return 3 * nb_channels;
+
+        case VBAN_BITFMT_32_INT:
+        case VBAN_BITFMT_32_FLOAT:
+            return 4 * nb_channels;
+
+        case VBAN_BITFMT_64_FLOAT:
+            return 8 * nb_channels;
+
+        default:
+            return 0;
+    }
+
+}
+
+int file_backend_init(audio_backend_handle_t* handle)
+{
+    struct file_backend_t* file_backend = 0;
+
+    if (handle == 0)
+    {
+        logger_log(LOG_FATAL, "%s: null handle pointer", __func__);
+        return -EINVAL;
+    }
+
+    file_backend = calloc(1, sizeof(struct file_backend_t));
+    if (file_backend == 0)
+    {
+        logger_log(LOG_FATAL, "%s: could not allocate memory", __func__);
+        return -ENOMEM;
+    }
+
+    file_backend->parent.is_fmt_supported   = file_is_fmt_supported;
+    file_backend->parent.open               = file_open;
+    file_backend->parent.close              = file_close;
+    file_backend->parent.write              = file_write;
+
+    *handle = (audio_backend_handle_t)file_backend;
+
+    return 0;
+    
+}
+
+int file_is_fmt_supported(audio_backend_handle_t handle, enum VBanBitResolution bit_resolution, unsigned int nb_channels, unsigned int rate)
+{
+    /*XXX*/
+    return 1;
+}
+
+int file_open(audio_backend_handle_t handle, char const* output_name, enum VBanBitResolution bit_resolution, unsigned int nb_channels, unsigned int rate, size_t buffer_size)
+{
+    struct file_backend_t* const file_backend = (struct file_backend_t*)handle;
+
+    if (handle == 0)
+    {
+        logger_log(LOG_FATAL, "%s: handle pointer is null", __func__);
+        return -EINVAL;
+    }
+
+    if(strcmp("", output_name))
+        file_backend->fd = open(output_name, O_CREAT|O_WRONLY|O_TRUNC, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+    else
+        file_backend->fd = STDOUT_FILENO; 
+
+        
+    if (file_backend->fd == -1)
+    {
+        logger_log(LOG_FATAL, "%s: open error", __func__); //
+	perror("open");
+        return -errno;
+    }
+
+    file_backend->sampleSize=vban_sample_length(bit_resolution, nb_channels);
+    
+    return 0;
+}
+
+int file_close(audio_backend_handle_t handle)
+{
+    int ret = 0;
+    struct file_backend_t* const file_backend = (struct file_backend_t*)handle;
+
+    if (handle == 0)
+    {
+        logger_log(LOG_FATAL, "%s: handle pointer is null", __func__);
+        return -EINVAL;
+    }
+
+    if (file_backend== 0)
+    {
+        /** nothing to do */
+        return 0;
+    }
+
+    if (file_backend->fd != STDOUT_FILENO)
+        ret = close(file_backend->fd);
+        
+    return ret;
+}
+
+int file_write(audio_backend_handle_t handle, char const* data, size_t nb_sample)
+{
+    int ret = 0;
+    struct file_backend_t* const file_backend = (struct file_backend_t*)handle;
+
+    if ((handle == 0) || (data == 0))
+    {
+        logger_log(LOG_ERROR, "%s: handle or data pointer is null", __func__);
+        return -EINVAL;
+    }
+
+    ret = write(file_backend->fd, (const void *)data, nb_sample * file_backend->sampleSize);
+    if (ret < 0)
+    {
+        logger_log(LOG_ERROR, "%s:", __func__);
+        perror("write");
+    }
+    return ret;
+}
+

--- a/src/file_backend.h
+++ b/src/file_backend.h
@@ -1,0 +1,29 @@
+/*
+ *  This file is part of vban_receptor.
+ *  Copyright (c) 2015 by Benoît Quiniou <quiniouben@yahoo.fr>
+ *  Copyright (c) 2017 by Markus Buschhoff <markus.buschhoff@tu-dortmund.de>
+ *
+ *  vban_receptor is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  vban_receptor is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with vban_receptor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __FILE_BACKEND_H__
+#define __FILE_BACKEND_H__
+
+#include "audio_backend.h"
+
+#define FILE_BACKEND_NAME   "file"
+int file_backend_init(audio_backend_handle_t* handle);
+
+#endif /*__FILE_BACKEND_H__*/
+

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ void usage()
     printf("-i, --ipaddress=IP      : MANDATORY. ipaddress to get stream from\n");
     printf("-p, --port=PORT         : MANDATORY. port to listen to\n");
     printf("-s, --streamname=NAME   : MANDATORY. streamname to play\n");
-    printf("-b, --backend=TYPE      : audio backend to use. possible values: alsa, pulseaudio, jack and pipe (EXPERIMENTAL). default is first in this list that is actually compiled\n");
+    printf("-b, --backend=TYPE      : audio backend to use. possible values: alsa, pulseaudio, jack, file (defaults to stdout) and pipe (EXPERIMENTAL). default is first in this list that is actually compiled\n");
     printf("-q, --quality=ID        : network quality indicator from 0 (low latency) to 4. default is 1\n");
     printf("-c, --channels=LIST     : channels from the stream to use. LIST is of form x,y,z,... default is to forward the stream as it is\n");
     printf("-o, --output=NAME       : Output device (server for jack backend) name , (as given by \"aplay -L\" output for alsa). using backend's default by default. not used for jack or pipe\n");


### PR DESCRIPTION
Enables "-b file" as backend, with stdout being the default (or writes to the file given in -o file). Tested and works here. Generally, it is slightly modified code from pipe_backend.c, but with a major fix (I believe pipe_backend does not work correctly): When using write() the number of bytes in the data buffer must be given, but pipe_backend sets the number of samples, which needs to be muliplied by the sample-width and number of channels to calculate bytes/sample (if there is not a more convenient way).