### PR TITLE
Add CMake build system support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.5..3.10)
+
+project(vban C)
+message(STATUS "CMake version ${CMAKE_VERSION}")
+
+# https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
+string(COMPARE EQUAL "${CMAKE_C_STANDARD}" "" no_cmake_c_standard_set)
+if(no_cmake_c_standard_set)
+    set(CMAKE_C_STANDARD 99)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(CMAKE_C_EXTENSIONS OFF)
+    message(STATUS "Using default C standard ${CMAKE_C_STANDARD}")
+else()
+    message(STATUS "Using user specified C standard ${CMAKE_C_STANDARD}")
+endif()
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+option(DISABLE_ALSA       "disable Alsa support"       OFF)
+option(DISABLE_PULSEAUDIO "disable PulseAudio support" OFF)
+option(DISABLE_JACK       "disable jack support"       OFF)
+
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+
+# add macro define 'DEBUG' to debug build
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+
+# enable various compiler warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -pedantic") # more warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wsign-compare")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow")
+# disable specific compiler warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-multichar") # also disables other unused warnings
+
+if(NOT DISABLE_ALSA)
+    find_package(ALSA QUIET)
+    if(ALSA_FOUND)
+        message(STATUS "found dependency ALSA: ${ALSA_VERSION_STRING} '${ALSA_INCLUDE_DIRS}' '${ALSA_LIBRARIES}'")
+        set(ALSA)
+    else()
+        message(STATUS "missing ALSA dependency, disabling backend")
+    endif()
+endif()
+if(NOT DISABLE_PULSEAUDIO)
+    find_package(PulseAudio QUIET)
+    if(PulseAudio_FOUND)
+        message(STATUS "found dependency PulseAudio: ${PULSEAUDIO_VERSION} '${PULSEAUDIO_INCLUDE_DIR}' '${PULSEAUDIO_LIBRARY}'")
+        set(PULSEAUDIO)
+    else()
+        message(STATUS "missing PulseAudio dependency, disabling backend")
+    endif()
+endif()
+if(NOT DISABLE_JACK)
+    include(FindPkgConfig)
+    pkg_search_module(JACK jack QUIET)
+    if(JACK_FOUND)
+        message(STATUS "found dependency JACK: ${JACK_VERSION} '${JACK_INCLUDEDIR}' '${JACK_LIBRARIES}'")
+        set(JACK)
+    else()
+        message(STATUS "missing JACK dependency, disabling backend")
+    endif()
+endif()
+
+
+# We want to compile source in src, so let's go there
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,100 @@
+add_executable(vban_receptor
+    receptor/main.c
+    common/version.h
+    common/audio.h
+    common/audio.c
+    common/packet.h
+    common/packet.c
+    common/backend/audio_backend.h
+    common/backend/audio_backend.c
+    common/backend/pipe_backend.c
+    common/backend/pipe_backend.h
+    common/backend/file_backend.c
+    common/backend/file_backend.h
+    common/socket.h
+    common/socket.c
+    common/stream.h
+    common/stream.c
+    vban/vban.h
+    common/logger.h
+    common/logger.c)
+
+add_executable(vban_emitter
+    emitter/main.c
+    common/version.h
+    common/audio.h
+    common/audio.c
+    common/packet.h
+    common/packet.c
+    common/backend/audio_backend.h
+    common/backend/audio_backend.c
+    common/backend/pipe_backend.c
+    common/backend/pipe_backend.h
+    common/backend/file_backend.c
+    common/backend/file_backend.h
+    common/socket.h
+    common/socket.c
+    common/stream.h
+    common/stream.c
+    vban/vban.h
+    common/logger.h
+    common/logger.c)
+
+add_executable(vban_sendtext
+    sendtext/main.c
+    common/version.h
+    common/socket.h
+    common/socket.c
+    vban/vban.h
+    common/logger.h
+    common/logger.c)
+    
+include(GNUInstallDirs)
+
+foreach(exe vban_receptor vban_emitter vban_sendtext)
+    target_include_directories(${exe} PRIVATE .)
+    if(ALSA)
+        target_compile_definition( ${exe} PRIVATE ALSA)
+        target_include_directories(${exe} PRIVATE "${ALSA_INCLUDE_DIRS}")
+        target_link_libraries(     ${exe} PRIVATE "${ALSA_LIBRARIES}")
+    endif()
+    if(PULSEAUDIO)
+        target_compile_definition( ${exe} PRIVATE PULSEAUDIO)
+        target_include_directories(${exe} PRIVATE "${PulSEAudio_INCLUDE_DIRS}")
+        target_link_libraries(     ${exe} PRIVATE "${PulseAudio_LIBRARIES}")
+    endif()
+    if(JACK)
+        target_compile_definition( ${exe} PRIVATE JACK)
+        target_include_directories(${exe} PRIVATE "${JACK_INCLUDE_DIR}")
+        target_link_libraries(     ${exe} PRIVATE "${JACK_LIBRARIES}")
+    endif()
+    
+    install(TARGETS ${exe} DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endforeach()
+
+if(ALSA)
+    target_sources(vban_receptor PRIVATE
+        common/backend/alsa_backend.h
+        common/backend/alsa_backend.c)
+    target_sources(vban_emitter PRIVATE
+        common/backend/alsa_backend.h
+        common/backend/alsa_backend.c)
+endif()
+
+if(PULSEAUDIO)
+    target_sources(vban_receptor PRIVATE
+        common/backend/pulseaudio_backend.h
+        common/backend/pulseaudio_backend.c)
+    target_sources(vban_emitter PRIVATE
+        common/backend/pulseaudio_backend.h
+        common/backend/pulseaudio_backend.c)
+endif()
+
+if(JACK)
+    target_sources(vban_receptor PRIVATE
+        common/backend/jack_backend.h
+        common/backend/jack_backend.c)
+    target_sources(vban_emitter PRIVATE
+        common/backend/jack_backend.h
+        common/backend/jack_backend.c)
+endif()


### PR DESCRIPTION
build with
```
cmake -S . -B _build -DCMAKE_INSTALL_PREFIX="${PWD}/_install"
cmake --build _build --target install
```

Then the `_install` directory contains the binaries
```
-- Installing: /home/nero/repos/vban/_install/bin/vban_receptor
-- Installing: /home/nero/repos/vban/_install/bin/vban_emitter
-- Installing: /home/nero/repos/vban/_install/bin/vban_sendtext
```

variables to disable the various backends
- `-DDISABLE_ALSA=Yes`
- `-DDISABLE_PULSEAUDIO=Yes`
- `-DDISABLE_JACK=Yes`

for example to build without JACK use the following command at cmake configuration
```
cmake -S . -B _build -DDISABLE_JACK=Yes
```