### PR TITLE
Continue main loop even when "packet prepared is invalid"

### DIFF
--- a/src/emitter/main.c
+++ b/src/emitter/main.c
@@ -241,13 +241,13 @@ int main(int argc, char* const* argv)
         {
             logger_log(LOG_ERROR, "%s: packet prepared is invalid", __func__);
             break;
-        }
-
-        ret = socket_write(main_s.socket, main_s.buffer, size + sizeof(struct VBanHeader));
-        if (ret < 0)
-        {
-            MainRun = 0;
-            break;
+        } else {
+            ret = socket_write(main_s.socket, main_s.buffer, size + sizeof(struct VBanHeader));
+            if (ret < 0)
+            {
+                MainRun = 0;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
vban_emitter would exit in case of overrun although ALSA automatically reconnects the broken pipe.
With this fix, the main loop will continue even in case of overrun, but of course the invalid packet is skipped.